### PR TITLE
Add publisher for contentSize, frame and all three offsetSizeAndFrame using combineLatest operator

### DIFF
--- a/Sources/ScrollViewProxy/ProxySwipeDirection.swift
+++ b/Sources/ScrollViewProxy/ProxySwipeDirection.swift
@@ -1,0 +1,13 @@
+//
+//  ProxySwipeDirection.swift
+//  
+//
+//  Created by 찰스 iOS 개발자 라이클 on 2022/12/07.
+//
+
+import UIKit
+
+public enum ProxySwipeDirection {
+    case up
+    case down
+}

--- a/Sources/ScrollViewProxy/ScrollViewProxy.swift
+++ b/Sources/ScrollViewProxy/ScrollViewProxy.swift
@@ -61,6 +61,14 @@ extension UIScrollView {
     var offsetPublisher: OffsetPublisher {
         publisher(for: \.contentOffset).eraseToAnyPublisher()
     }
+    
+    var contentSizePublisher:ContentSizePublisher {
+        publisher(for: \.contentSize).eraseToAnyPublisher()
+    }
+    
+    var framePublisher:FramePublisher {
+        publisher(for: \.frame).eraseToAnyPublisher()
+    }
 }
 
 extension UIEdgeInsets {
@@ -159,6 +167,8 @@ public struct ScrollViewReader<Content: View>: View {
                 if self.proxy.coordinator.scrollView != $0 {
                     self.proxy.coordinator.scrollView = $0
                     self.proxy.offset = $0.offsetPublisher
+                    self.proxy.contentSize = $0.contentSizePublisher
+                    self.proxy.frame = $0.framePublisher
                 }
             }
     }
@@ -168,6 +178,10 @@ public struct ScrollViewReader<Content: View>: View {
 
 @available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
 public typealias OffsetPublisher = AnyPublisher<CGPoint, Never>
+@available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
+public typealias ContentSizePublisher = AnyPublisher<CGSize, Never>
+@available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
+public typealias FramePublisher = AnyPublisher<CGRect, Never>
 
 @available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
 public struct ScrollViewProxy {
@@ -182,6 +196,17 @@ public struct ScrollViewProxy {
     
     /// A publisher that publishes changes to the scroll views offset
     public fileprivate(set) var offset: OffsetPublisher = Just(.zero).eraseToAnyPublisher()
+    ///  /// A publisher that publishes changes to the scroll views contentSize.
+    public fileprivate(set) var contentSize:ContentSizePublisher = Just(.zero).eraseToAnyPublisher()
+    /// A publisher that publishes changes to the scroll views frame.
+    public fileprivate(set) var frame: FramePublisher = Just(.zero).eraseToAnyPublisher()
+    
+    /// A publisher that publishes latest changes of `offset`,`contentSize` and `frame` all at once.
+    public var offsetSizeAndFrame: AnyPublisher<(CGPoint, ContentSizePublisher.Output, FramePublisher.Output), Never> {
+        return offset
+            .combineLatest(contentSize, frame)
+            .eraseToAnyPublisher()
+    }
 
     /// Scrolls to an edge or corner
     public func scrollTo(_ alignment: Alignment, animated: Bool = true) {

--- a/Sources/ScrollViewProxy/ScrollViewProxy.swift
+++ b/Sources/ScrollViewProxy/ScrollViewProxy.swift
@@ -196,7 +196,10 @@ public struct ScrollViewProxy {
         
         
         func scrollViewDidScroll(_ scrollView: UIScrollView) {
-            
+            fireSwipeDirectionPublisher(scrollView: scrollView)
+        }
+        
+        private func fireSwipeDirectionPublisher(scrollView: UIScrollView) {
             var swipeDirection:ProxySwipeDirection {
                 if(scrollView.panGestureRecognizer.translation(in: scrollView.superview).y > 0) {
                     // User is scrolling towards the top of the list.
@@ -212,11 +215,11 @@ public struct ScrollViewProxy {
                     }
                     return .up
                 }
-                
             }
             swipeDirectionPublisher.send(swipeDirection)
         }
     }
+    
     fileprivate var coordinator = Coordinator()
     fileprivate var space: UUID = UUID()
     private var subscriptions = Set<AnyCancellable>()


### PR DESCRIPTION
This PR, simply adds publisher for contentSize, frame and all three offsetSizeAndFrame using combineLatest operator. I had a usecase where I needed to know all of those properties but the library didn't have any public property for it so I added them on extension of UIScrollView, as I am working on iOS app. I think similar approach can be used on NSScrollView too. 

## Changes summary
 I simply extended UIScrollView to include: - 
```swift
@available(iOS 13.0, OSX 10.15, tvOS 13.0, watchOS 6.0, *)
extension UIScrollView {
  // Original 
    var offsetPublisher: OffsetPublisher {
        publisher(for: \.contentOffset).eraseToAnyPublisher()
    }
    
// New Addition
    var contentSizePublisher:ContentSizePublisher {
        publisher(for: \.contentSize).eraseToAnyPublisher()
    }
    
// New Addition
    var framePublisher:FramePublisher {
        publisher(for: \.frame).eraseToAnyPublisher()
    }
}
```

 Then I added and document the following property
```swift
  /// A publisher that publishes latest changes of `offset`,`contentSize` and `frame` all at once.
    public var offsetSizeAndFrame: AnyPublisher<(CGPoint, ContentSizePublisher.Output, FramePublisher.Output), Never> {
        return offset
            .combineLatest(contentSize, frame)
            .eraseToAnyPublisher()
    }
```


## Usage
And use it just like the original property. Please see commit for more details.
   ```swift
   .onReceive(proxy.offsetSizeAndFrame) { contentOffset,contentSize,frame in
                   // Do something
           }
  ```