### PR TITLE
fix save geometry bug

### DIFF
--- a/Sources/ScrollViewProxy/ScrollViewProxy.swift
+++ b/Sources/ScrollViewProxy/ScrollViewProxy.swift
@@ -249,6 +249,9 @@ public struct ScrollViewProxy {
     }
 
     fileprivate func save(geometry: GeometryProxy, for id: AnyHashable) {
+        if coordinator.frames[id] != nil {
+            return
+        }
         coordinator.frames[id] = geometry.frame(in: .named(space))
     }
 }


### PR DESCRIPTION
there's a bug in save geometry, so in ios 13 if the swiftui component has already assigned 2 time or more to `coordinator.frames[id]` with `scrollId`, it will produce bug that makes ios 13 crash