### PR TITLE
Fix minimum iOS version to iOS 13 for SwiftUI compatibility.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     name: "ScrollViewProxy",
     platforms: [
         .macOS(.v10_13),
-        .iOS(.v11),
+        .iOS(.v13),
         .tvOS(.v11)
     ],
     products: [


### PR DESCRIPTION
I have noticed that the minimum iOS version was mistakenly stated as iOS 11 instead of iOS 13, which led to build failures when SwiftPM attempted to resolve the package graph. In order to resolve this issue, I have updated the minimum iOS version to iOS 13, which is the minimum version that supports SwiftUI.